### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,19 @@ You can edit the texts that are going to be the foundation of the publication. Y
 
 - ds_thesis submodule is optional. If you don't have access, you can skip initializing it and still work with the main repo.
 - external/bibliography is a submodule for the common literature from deRSE
+  initialize with `git submodule init external/bibliography`
 
 
 ## How To Run
 
-- cd generation # go in generation dir
-- install python requirements from requirement.txt
-- python generate_all.py # run the templating logic
-- cd .. # go back in root dir
+- `cd generation` # go in generation dir
+- install python requirements from requirements.txt
+  ```
+  pip install -r requirements.txt
+  ```
+- `python generate_all.py` # run the templating logic
+- `cd ..` # go back in root dir
 - Windows PS:
-  - quarto render --profile doc; quarto preview --profile website
+  - `quarto render --profile doc; quarto preview --profile website`
 - Linux/ Windows CMD:
-  - quarto render --profile doc && quarto preview --profile website
+  - `quarto render --profile doc && quarto preview --profile website`


### PR DESCRIPTION
Add the missing information discovered during the workshop.

It would be nice if the `generate_all.py` script would allow out-of place builds, so you don't need to be in that folder.
You would probably need to generate absolute paths at runtime for that.